### PR TITLE
change embassy-traits dependency to specify a version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["embedded", "no-std", "hardware-support"]
 edition = "2018"
 
 [dependencies]
-embassy-traits = { git = "https://github.com/embassy-rs/embassy.git", rev = "db889da" }
+embassy-traits = "0.1.0"
 embedded-hal = "0.2.3"
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 defmt = { version = "0.2.3", optional = true }


### PR DESCRIPTION
this lets users patch embassy to a version of their choosing, like so:

```toml
[patch.crates-io]
embassy             = { version = "0.1.0", git = "https://github.com/embassy-rs/embassy", rev = "9fec8330" }
embassy-traits      = { version = "0.1.0", git = "https://github.com/embassy-rs/embassy", rev = "9fec8330" }
```